### PR TITLE
Use current user when adding PostgreSQL user

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -9,7 +9,7 @@ sudo apt-get update
 sudo apt-get -y install postgresql postgresql-contrib linux-generic-lts-vivid
 sudo update-rc.d postgresql enable
 set +e
-sudo -u postgres createuser -d --superuser ubuntu
+sudo -u postgres createuser -d --superuser `whoami`
 createuser --superuser root
 createdb atc
 set -e

--- a/setup.bash
+++ b/setup.bash
@@ -9,7 +9,7 @@ sudo apt-get update
 sudo apt-get -y install postgresql postgresql-contrib linux-generic-lts-vivid
 sudo update-rc.d postgresql enable
 set +e
-sudo -u postgres createuser -d --superuser `whoami`
+sudo -u postgres createuser -d --superuser $(whoami)
 createuser --superuser root
 createdb atc
 set -e


### PR DESCRIPTION
This uses whoami to determine current user instead of assuming "ubuntu" as the username.

This makes it work with Vagrant puppetlabs/ubuntu-14.04-64-nocm image (which has a username of 'vagrant' for current user)
