### PR TITLE
Detect and use PostgreSQL unix sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Use at your own risk.
 1. `sudo apt-get install git`
 1. `git clone https://github.com/motevets/concourse-in-a-box.git`
 1. `concourse-in-a-box/setup.bash`
-1. `sudo reboot`
-1. Wait for reboot, and shell back into your instance.
 1. `sudo ciab`
 
 ## Credit

--- a/ciab
+++ b/ciab
@@ -21,12 +21,18 @@ if [ -z "$concourse" ]; then
   exit 1
 fi
 
+# Detect Ubuntu's PostgreSQL's Unix Socket connector path.
+POSTGRESURI=""
+for f in /var/run/postgresql/.s.PGSQL.*; do
+    POSTGRESURI=" --postgres-data-source postgres:///atc?host=/var/run/postgresql"
+done
+
 $concourse web \
   --development-mode \
   --session-signing-key $session_key \
   --tsa-bind-port 2223 \
   --tsa-host-key $tsa_key \
-  --tsa-authorized-keys ${worker_key}.pub &
+  --tsa-authorized-keys ${worker_key}.pub ${POSTGRESURI} &
 
 trap "kill $!" 0
 

--- a/setup.bash
+++ b/setup.bash
@@ -13,13 +13,6 @@ sudo -u postgres createuser -d --superuser ubuntu
 createuser --superuser root
 createdb atc
 set -e
-cat <<EOF | sudo tee /etc/postgresql/9.3/main/pg_hba.conf
-# TYPE  DATABASE        USER            ADDRESS                 METHOD
-local   all             postgres                                peer
-local   all             all                                     peer
-host    all             all             127.0.0.1/32            trust
-host    all             all             ::1/128                 trust
-EOF
 
 wget https://github.com/concourse/concourse/releases/download/v1.0.0/concourse_linux_amd64
 sudo install --owner=root --group=root --mode=744 concourse_linux_amd64 /usr/local/sbin/concourse
@@ -27,4 +20,4 @@ sudo install --owner=root --group=root --mode=744 ciab /usr/local/sbin/ciab
 
 set +x
 
-printf "\n🛩 Ready to go! Reboot and run 'sudo ciab' to start concourse.\n\n"
+printf "\n🛩 Ready to go! Run 'sudo ciab' to start concourse.\n\n"


### PR DESCRIPTION
This makes the following changes:
- Detects and uses /var/run/posgresql if that's configured unix socket path in ciab (default for Ubuntu)
- Removes reconfiguration of Postfix and reboot step, now unnecessary
- Updates printf at end of setup so that it no longer asks user to reboot.
- Update README to remove reboot steps.
